### PR TITLE
Include Deploy on Platform.sh button

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ following micro-service based architecture:
     
 ## Hosting
 
-
+<p align="center">
+<a href="https://console.platform.sh/projects/create-project?template=https://github.com/whiteskyweb/Power-Stack.git&utm_content=whiteskyweb_power_stack&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform">
+    <img src="https://platform.sh/images/deploy/lg-blue.svg" alt="Deploy on Platform.sh" width="180px" />
+</a>
+</p>
 
 ## Requirements
 


### PR DESCRIPTION
The repository has Platform.sh configuration files, as well as an empty section for Hosting in the README.  This PR offers a Deploy on Platform.sh button to make it quick and straightforward to deploy this Platform-compatible repo on Platform.sh.  (The utm codes are just so we know where the new projects are coming from.)

For background on the DoP buttons: https://docs.platform.sh/frameworks/deploy-button.html